### PR TITLE
Possible solution for incorrect component action triggers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 *.iws
 /*.idea
 /*target
+
+#Eclipse
+*.project
+*.classpath

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.covertlizard</groupId>
     <artifactId>panel</artifactId>
-    <version>1.9-SNAPSHOT</version>
+    <version>1.9.1</version>
     <name>Panel</name>
 
     <!--Repositories-->

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <!--Spigot's Minecraft server wrapper, complete with Bukkit API-->
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
+            <artifactId>spigot-api</artifactId>
             <version>1.8.8-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/com/github/covertlizard/panel/Core.java
+++ b/src/main/java/com/github/covertlizard/panel/Core.java
@@ -38,8 +38,8 @@ public class Core extends JavaPlugin implements Listener
         if(!this.panels.containsKey(event.getInventory())) return;
         Panel panel = this.panels.get(event.getInventory());
         if(!panel.isGrief()) event.setCancelled(true);
-        if(!panel.getCurrent().getComponents().containsKey(event.getSlot())) return;
-        for(java.util.Map.Entry<ClickType, Layout.Action> entry : panel.getCurrent().getComponents().get(event.getSlot()).getActions().entrySet())
+        if(!panel.getCurrent().getComponents().containsKey(event.getRawSlot())) return;
+        for(java.util.Map.Entry<ClickType, Layout.Action> entry : panel.getCurrent().getComponents().get(event.getRawSlot()).getActions().entrySet())
         {
             if(entry.getKey() == null || entry.getKey().equals(event.getClick()))
             {


### PR DESCRIPTION
Ran into a problem where, when using a chest panel, clicking in the players original inventory would act like clicks in the chest inventory.

Patched by changing the component check to use RawSlot values instead of Slot values.
Could break other kinds of inventories though.
