### PR TITLE
Added a component which handles all clicks to the bottom inventory.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.covertlizard</groupId>
     <artifactId>panel</artifactId>
-    <version>1.9.1</version>
+    <version>1.10.0</version>
     <name>Panel</name>
 
     <!--Repositories-->

--- a/src/main/java/com/github/covertlizard/panel/Core.java
+++ b/src/main/java/com/github/covertlizard/panel/Core.java
@@ -5,8 +5,12 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import com.github.covertlizard.panel.Layout.Action;
+import com.github.covertlizard.panel.Layout.Component;
 
 import java.util.HashMap;
 
@@ -35,11 +39,32 @@ public class Core extends JavaPlugin implements Listener
     @EventHandler
     private final void onInventoryClickEvent(InventoryClickEvent event)
     {
-        if(!this.panels.containsKey(event.getInventory())) return;
+        if(!this.panels.containsKey(event.getInventory()))
+        	return;
+        
         Panel panel = this.panels.get(event.getInventory());
-        if(!panel.isGrief()) event.setCancelled(true);
-        if(!panel.getCurrent().getComponents().containsKey(event.getRawSlot())) return;
-        for(java.util.Map.Entry<ClickType, Layout.Action> entry : panel.getCurrent().getComponents().get(event.getRawSlot()).getActions().entrySet())
+        
+        if(!panel.isGrief())
+        	event.setCancelled(true);
+        
+        Layout current = panel.getCurrent();
+        
+    	processComponent(current.getComponents().get(event.getRawSlot()), event);
+        
+        if (event.getClickedInventory() != null && event.getClickedInventory().getType() == InventoryType.PLAYER)
+        	processComponent(current.getComponents().get(null), event);
+    }
+    
+    /**
+     * Helper function to process all actions associated with a component.
+     * @param component The component whose actions need to be processed.
+     * @param event The event used to process the actions.
+     */
+    private final void processComponent(Component component, InventoryClickEvent event)
+    {
+    	if (component == null) return;
+    	
+    	for(java.util.Map.Entry<ClickType, Layout.Action> entry : component.getActions().entrySet())
         {
             if(entry.getKey() == null || entry.getKey().equals(event.getClick()))
             {

--- a/src/main/java/com/github/covertlizard/panel/Layout.java
+++ b/src/main/java/com/github/covertlizard/panel/Layout.java
@@ -46,6 +46,18 @@ public class Layout
         this.components.put(position, component);
         return component;
     }
+    
+    /**
+     * Create a new component builder.
+     * This component will be used for all calls to clicks on the bottom inventory. 
+     * @return The Component builder instance.
+     */
+    public Component component()
+    {
+    	Component component = new Component();
+    	components.put(null, component);
+    	return component;
+    }
 
     /**
      * Introduces a new ItemStack into the layout
@@ -92,11 +104,19 @@ public class Layout
         return 0;
     }
 
+    /**
+     * Returns the components in use by the layout.
+     * @return A reference to the map containing the layout Components.
+     */
     public HashMap<Integer, Component> getComponents()
     {
         return this.components;
     }
 
+    /**
+     * Returns the ItemStacks in use by the layout.
+     * @return A reference to the map containing the layout ItemStacks.
+     */
     public HashMap<Integer, ItemStack> getStacks()
     {
         return this.stacks;


### PR DESCRIPTION
I ran into a problem where I needed to be able to handle all clicks to the bottom inventory of a panel (Selecting an item, for example) So I added a component which does that. I'm storing the component in the components map using a null key, similar to how you have done actions.

I changed a bit of your format, so I don't think you'll accept this. I just thought that you might want a feature like this/have a way you would rather do it.
